### PR TITLE
Current apache-hardening not working with recent geerlingguy.apache role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,4 @@ Berksfile.lock
 
 ansible.cfg
 hosts
-default.yml
 roles/bennojoy.mysql/

--- a/.kitchen.vagrant.yml
+++ b/.kitchen.vagrant.yml
@@ -4,7 +4,6 @@ driver:
 
 provisioner:
   name: ansible_playbook
-  test_repo_uri: https://github.com/hardening-io/tests-apache-hardening.git
   hosts: all
   require_ansible_repo: false
   require_ansible_omnibus: true
@@ -13,53 +12,27 @@ provisioner:
   ansible_verbose: true
   roles_path: ../ansible-apache-hardening/
   playbook: default.yml
+  requirements_path: requirements.yml
+  sudo_command: 'sudo -E -H'
+
+transport:
+  max_ssh_sessions: 5
 
 platforms:
-- name: ubuntu-12.04
-  driver_config:
-    box: opscode-ubuntu-12.04
-    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-12.04_chef-provisionerless.box
 - name: ubuntu-14.04
-  driver_config:
-    box: opscode-ubuntu-14.04
-    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04_chef-provisionerless.box
-- name: centos-6.4
-  driver_config:
-    box: opscode-centos-6.4
-    box_url: https://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-6.4_provisionerless.box
-- name: centos-6.5
-  driver_config:
-    box: opscode-centos-6.5
-    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.5_chef-provisionerless.box
-- name: oracle-6.4
-  driver_config:
-    box: oracle-6.4
-    box_url: https://storage.us2.oraclecloud.com/v1/istoilis-istoilis/vagrant/oel64-64.box
-- name: oracle-6.5
-  driver_config:
-    box: oracle-6.5
-    box_url: https://storage.us2.oraclecloud.com/v1/istoilis-istoilis/vagrant/oel65-64.box
-- name: debian-6
-  driver_config:
-    box: debian-6
-    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian-6.0.10_chef-provisionerless.box
-- name: debian-7
-  driver_config:
-    box: debian-7
-    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian-7.8_chef-provisionerless.box
-- name: debian-8
-  driver_config:
-    box: debian-8
-    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian-8.1_chef-provisionerless.box
+- name: ubuntu-16.04
+- name: centos-6.8
+- name: centos-7.3
+- name: oracle-6.8
+- name: oracle-7.3
+- name: debian-7.11
+- name: debian-8.7
 
 verifier:
   name: inspec
   sudo: true
   inspec_tests:
-    - https://github.com/dev-sec/tests-apache-hardening
+    - https://github.com/dev-sec/apache-baseline/
 
 suites:
-- name: apache-ansible_1.9
-  provisioner:
-    ansible_version: 1.9.4
-- name: apache-ansible_latest
+- name: apache

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,64 +1,102 @@
 ---
 driver:
   name: docker
+  use_sudo: false
+  privileged: true
+  http_proxy: <%= ENV['http_proxy'] || nil %>
+  https_proxy: <%= ENV['https_proxy'] || nil %>
 
 transport:
-  max_ssh_sessions: 2
+  max_ssh_sessions: 5
+
 provisioner:
   name: ansible_playbook
   hosts: all
   require_ansible_repo: false
-  require_ansible_omnibus: true
   require_chef_for_busser: false
   require_ruby_for_busser: false
   ansible_verbose: true
   ansible_diff: true
-  hosts: all
+  requirements_path: requirements.yml
   roles_path: ../ansible-apache-hardening/
-  playbook: default.yml
-
-verifier:
-  name: inspec
-  sudo: true
-  inspec_tests:
-    - https://github.com/dev-sec/tests-apache-hardening
+  http_proxy: <%= ENV['http_proxy'] || nil %>
+  https_proxy: <%= ENV['https_proxy'] || nil %>
+  playbook: tests/default.yml
 
 platforms:
-- name: ubuntu-12.04
+- name: centos6-ansible-latest
   driver:
-    image: ubuntu:12.04
-- name: ubuntu-14.04
+    image: rndmh3ro/docker-centos6-ansible:latest
+    platform: centos
+- name: centos7-ansible-latest
   driver:
-    image: ubuntu:14.04
-- name: ubuntu-16.04
+    image: rndmh3ro/docker-centos7-ansible:latest
+    platform: centos
+    run_command: /sbin/init
+    provision_command:
+      - sed -i 's/UsePAM yes/UsePAM no/g' /etc/ssh/sshd_config
+      - systemctl enable sshd.service
+- name: oracle6-ansible-latest
   driver:
-    image: ubuntu:16.04
-- name: centos-6.6
+    image: rndmh3ro/docker-oracle6-ansible:latest
+    platform: centos
+- name: oracle7-ansible-latest
   driver:
-    image: centos:6.6
-- name: centos-6.7
+    image: rndmh3ro/docker-oracle7-ansible:latest
+    run_command: /sbin/init
+    platform: centos
+    provision_command:
+      - sed -i 's/UsePAM yes/UsePAM no/g' /etc/ssh/sshd_config
+      - systemctl enable sshd.service
+- name: ubuntu1404-ansible-latest
   driver:
-    image: centos:6.7
-- name: centos-7
+    image: rndmh3ro/docker-ubuntu1404-ansible:latest
+    platform: ubuntu
+- name: ubuntu1604-ansible-latest
   driver:
-    image: centos:7
-    privileged: true
-    run_command: /usr/sbin/init
-- name: debian-7
+    image: rndmh3ro/docker-ubuntu1604-ansible:latest
+    platform: ubuntu
+    run_command: /sbin/init
+    provision_command:
+      - systemctl enable ssh.service
+- name: ubuntu1804-ansible-latest
   driver:
-    image: debian:7
-- name: debian-8
+    image: rndmh3ro/docker-ubuntu1804-ansible:latest
+    platform: ubuntu
+    run_command: /sbin/init
+    provision_command:
+      - systemctl enable ssh.service
+- name: debian7-ansible-latest
   driver:
-    image: debian:8
+    image: rndmh3ro/docker-debian7-ansible:latest
+    platform: debian
+- name: debian8-ansible-latest
+  driver:
+    image: rndmh3ro/docker-debian8-ansible:latest
+    platform: debian
+- name: debian9-ansible-latest
+  driver:
+    image: rndmh3ro/docker-debian9-ansible:latest
+    platform: debian
+    run_command: /sbin/init
+    provision_command:
+      - apt install -y systemd-sysv
+      - systemctl enable ssh.service
+- name: amazon-ansible-latest
+  driver:
+    image: rndmh3ro/docker-amazon-ansible:latest
+    platform: centos
+    run_command: /sbin/init
+    provision_command:
+      - sed -i 's/UsePAM yes/UsePAM no/g' /etc/ssh/sshd_config
+      - systemctl enable sshd.service
 
 verifier:
   name: inspec
   sudo: true
   inspec_tests:
-    - https://github.com/dev-sec/tests-apache-hardening
+    #- https://github.com/dev-sec/apache-baseline
+    - ../apache-baseline
 
 suites:
-- name: apache-ansible_1.9
-  provisioner:
-    ansible_version: 1.9.4
-- name: apache-ansible_latest
+- name: apache

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -96,7 +96,8 @@ verifier:
   sudo: true
   inspec_tests:
     #- https://github.com/dev-sec/apache-baseline
-    - ../apache-baseline
+    - https://github.com/szEvEz/apache-baseline/tree/newbaseline
+    # - ../apache-baseline
 
 suites:
 - name: apache

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ script:
   - 'docker run --detach --volume="${PWD}":/etc/ansible/roles/ansible-apache-hardening:ro ${run_opts} rndmh3ro/docker-${distro}-ansible:${version} "${init}" > "${container_id}"'
   
   # Install geerlingguy.apache as a prereq
-  - 'docker exec "$(cat ${container_id})" ansible-galaxy install geerlingguy.apache'
+  - 'docker exec "$(cat ${container_id})" ansible-galaxy install -c geerlingguy.apache'
 
   # Test role.
   - 'docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/ansible-apache-hardening/spec/travis.yml --diff'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,72 @@
 ---
-language: python
-python: "2.7"
+services: docker
+
+env:
+  - distro: centos6
+    version: latest
+    init: /sbin/init
+
+  - distro: centos7
+    init: /lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    version: latest
+
+  - distro: oracle6
+    version: latest
+    init: /sbin/init
+
+#  - distro: oracle7
+#    init: /lib/systemd/systemd
+#    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+#    version: latest
+
+  - distro: ubuntu1404
+    version: latest
+    init: /sbin/init
+
+  - distro: ubuntu1604
+    version: latest
+    init: /lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+
+  - distro: ubuntu1804
+    version: latest
+    init: /lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+
+  - distro: debian7
+    version: latest
+    init: /sbin/init
+
+  - distro: debian8
+    version: latest
+    init: /sbin/init
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+
+  - distro: debian9
+    version: latest
+    init: /lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+
+  - distro: amazon
+    init: /lib/systemd/systemd
+    version: latest
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+
 before_install:
- - sudo apt-get update -qq
- - sudo apt-get install -qq python-apt python-pycurl python-mysqldb
-install:
-  - pip install ansible
-  - echo -e 'localhost ansible_connection=local' > spec/inventory
-  - echo -e '[defaults]\nroles_path = ./roles\nhostfile = ./spec/inventory' > ansible.cfg
+  # Pull container
+  - 'docker pull rndmh3ro/docker-${distro}-ansible:${version}'
 
 script:
-  - ansible-playbook --syntax-check spec/travis.yml
-  - ansible-playbook --sudo -v --diff spec/travis.yml
+  - container_id=$(mktemp)
+  # Run container in detached state.
+  - 'docker run --detach --volume="${PWD}":/etc/ansible/roles/ansible-apache-hardening:ro ${run_opts} rndmh3ro/docker-${distro}-ansible:${version} "${init}" > "${container_id}"'
+
+   # Test role.
+  - 'docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/ansible-apache-hardening/spec/travis.yml --diff --skip-tags "sysctl"'
+
+   # Verify role
+  - 'inspec exec https://github.com/dev-sec/apache-baseline/ -t docker://$(cat ${container_id}) --no-distinct-exit'
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,11 +61,14 @@ script:
   - container_id=$(mktemp)
   # Run container in detached state.
   - 'docker run --detach --volume="${PWD}":/etc/ansible/roles/ansible-apache-hardening:ro ${run_opts} rndmh3ro/docker-${distro}-ansible:${version} "${init}" > "${container_id}"'
+  
+  # Install geerlingguy.apache as a prereq
+  - 'docker exec "$(cat ${container_id})" ansible-galaxy install geerlingguy.apache'
 
-   # Test role.
-  - 'docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/ansible-apache-hardening/spec/travis.yml --diff --skip-tags "sysctl"'
+  # Test role.
+  - 'docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/ansible-apache-hardening/spec/travis.yml --diff'
 
-   # Verify role
+  # Verify role
   - 'inspec exec https://github.com/dev-sec/apache-baseline/ -t docker://$(cat ${container_id}) --no-distinct-exit'
 
 notifications:

--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,6 @@ source 'https://rubygems.org'
 
 group :test do
   gem 'rake'
-  gem 'foodcritic', '~> 4.0'
-  gem 'thor-foodcritic'
-  gem 'coveralls',  require: false
 end
 
 group :development do

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# apache-hardening (Ansible role)
+
+[![Build Status](http://img.shields.io/travis/dev-sec/ansible-apache-hardening.svg)][1]
+[![Gitter Chat](https://badges.gitter.im/Join%20Chat.svg)][2]
+[![Ansible Galaxy](https://img.shields.io/badge/galaxy-os--hardening-660198.svg)][3]
+
+## Description
+
+This role provides numerous security-related configurations, providing all-round base protection.  It is intended to be compliant with the [DevSec Apache Baseline](https://github.com/dev-sec/apache-baseline).
+
+
+[1]: http://travis-ci.org/dev-sec/ansible-apache-hardening
+[2]: https://gitter.im/dev-sec/general
+[3]: https://galaxy.ansible.com/dev-sec/ansible-apache-hardening

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 
 This role provides numerous security-related configurations, providing all-round base protection.  It is intended to be compliant with the [DevSec Apache Baseline](https://github.com/dev-sec/apache-baseline).
 
+## Variables
+
+| Name           | Default Value | Description                        |
+| -------------- | ------------- | -----------------------------------| 
 
 [1]: http://travis-ci.org/dev-sec/ansible-apache-hardening
 [2]: https://gitter.im/dev-sec/general

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,1 @@
+- geerlingguy.apache

--- a/spec/travis.yml
+++ b/spec/travis.yml
@@ -1,3 +1,4 @@
 - hosts: localhost
   roles:
+    - geerlingguy.apache
     - ansible-apache-hardening

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
   tags: always
 
 - name: config should not be worldwide read- or writeable | DTAG SEC Req 3.36-3
-  file: path="{{apache_server_root}}" recurse=yes mode="o-rwx" owner="{{apache_user}}" group="{{apache_group}}"
+  file: path="{{apache_server_root}}" recurse=yes mode="o-rwx" owner=root group=root
 
 - name: Get installed version of Apache.
   shell: "{{ apache_daemon_path }}/{{ apache_daemon }} -v"
@@ -16,7 +16,7 @@
     apache_version: '{{ _apache_version.stdout.split()[2].split("/")[1] }}'
 
 - name: create directories in case they don't exist
-  file: path="{{item}}" state=directory owner="{{apache_user}}" group="{{apache_group}}" mode=0740
+  file: path="{{item}}" state=directory owner=root group=root mode=0740
   with_items:
     - "{{apache_server_root}}"
     - "{{apache_confd_dir}}"
@@ -26,8 +26,9 @@
 
 
 - name: configure httpd.conf
-  template: src="httpd.conf.j2" dest="{{apache_conf_dir}}/{{apache_conf_file}}" owner="{{apache_user}}" group="{{apache_group}}" mode=0640 backup=yes
+  template: src="httpd.conf.j2" dest="{{apache_conf_dir}}/{{apache_conf_file}}" owner=root group=root mode=0640 backup=yes
   notify: restart apache
 
 - name: harden apache
-  template: src="hardening.conf.j2" dest="{{apache_confd_dir}}/90.hardening.conf" owner="{{apache_user}}" group="{{apache_group}}" mode=0640 backup=yes
+  template: src="hardening.conf.j2" dest="{{apache_confd_dir}}/90.hardening.conf" owner=root group=root mode=0640 backup=yes
+  template: src="ssl.conf.j2" dest="{{apache_confd_dir}}/ssl.conf" owner=root group=root mode=0640 backup=yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
     apache_version: '{{ _apache_version.stdout.split()[2].split("/")[1] }}'
 
 - name: create directories in case they don't exist
-  file: path="{{item}}" state=directory owner=root group=root mode=0740
+  file: path="{{item}}" state=directory owner=root group=root mode=0750
   with_items:
     - "{{apache_server_root}}"
     - "{{apache_confd_dir}}"
@@ -29,6 +29,8 @@
   template: src="httpd.conf.j2" dest="{{apache_conf_dir}}/{{apache_conf_file}}" owner=root group=root mode=0640 backup=yes
   notify: restart apache
 
-- name: harden apache
+- name: harden apache 1
   template: src="hardening.conf.j2" dest="{{apache_confd_dir}}/90.hardening.conf" owner=root group=root mode=0640 backup=yes
+  
+- name: harden apache 2
   template: src="ssl.conf.j2" dest="{{apache_confd_dir}}/ssl.conf" owner=root group=root mode=0640 backup=yes

--- a/templates/httpd.conf.j2
+++ b/templates/httpd.conf.j2
@@ -31,6 +31,9 @@ AccessFileName .htaccess
   AllowOverride None
 </Directory>
 
+# FIXME: Only include modules that are really needed
+Include conf.modules.d/*.conf
+
 # TODO: variablen!
 DefaultType none
 HostnameLookups Off
@@ -41,7 +44,7 @@ EnableSendfile {{ apache_sendfile }}
 AllowEncodedSlashes "{{ apache_allow_encoded_slashes }}"
 {% endif %}
 
-Include "{{ apache_mod_load_dir }}/*.load"
+IncludeOptional "{{ apache_mod_load_dir }}/*.load"
 {% if apache_mod_load_dir != apache_confd_dir and apache_mod_load_dir != apache_vhost_load_dir %}
 Include "{{ apache_mod_load_dir }}/*.conf"
 {% endif %}

--- a/templates/httpd.conf.j2
+++ b/templates/httpd.conf.j2
@@ -89,6 +89,10 @@ Alias /error/ "{{ apache_error_documents_path }}/"
   ForceLanguagePriority Prefer Fallback
 </Directory>
 
+<IfModule mime_module>
+    TypesConfig /etc/mime.types
+</IfModule>
+
 ErrorDocument 400 /error/HTTP_BAD_REQUEST.html.var
 ErrorDocument 401 /error/HTTP_UNAUTHORIZED.html.var
 ErrorDocument 403 /error/HTTP_FORBIDDEN.html.var

--- a/templates/ssl.conf.j2
+++ b/templates/ssl.conf.j2
@@ -1,0 +1,46 @@
+# {{ansible_managed}}
+
+Listen 443 https
+
+SSLPassPhraseDialog exec:/usr/libexec/httpd-ssl-pass-dialog
+
+SSLSessionCache         shmcb:/run/httpd/sslcache(512000)
+SSLSessionCacheTimeout  300
+
+SSLRandomSeed startup file:/dev/urandom  256
+SSLRandomSeed connect builtin
+
+SSLCryptoDevice builtin
+
+<VirtualHost _default_:443>
+
+ErrorLog logs/ssl_error_log
+TransferLog logs/ssl_access_log
+LogLevel warn
+
+SSLEngine on
+
+SSLProtocol all -SSLv2 -SSLv3
+
+SSLCipherSuite HIGH:3DES:!aNULL:!MD5:!SEED:!IDEA
+SSLHonorCipherOrder on
+
+SSLCertificateFile /etc/pki/tls/certs/localhost.crt
+
+SSLCertificateKeyFile /etc/pki/tls/private/localhost.key
+
+<Files ~ "\.(cgi|shtml|phtml|php3?)$">
+    SSLOptions +StdEnvVars
+</Files>
+<Directory "/var/www/cgi-bin">
+    SSLOptions +StdEnvVars
+</Directory>
+
+BrowserMatch "MSIE [2-5]" \
+         nokeepalive ssl-unclean-shutdown \
+         downgrade-1.0 force-response-1.0
+
+CustomLog logs/ssl_request_log \
+          "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
+
+</VirtualHost>

--- a/tests/default.yml
+++ b/tests/default.yml
@@ -1,0 +1,4 @@
+- hosts: localhost
+  roles:
+    - geerlingguy.apache
+    - ansible-apache-hardening


### PR DESCRIPTION
This PR is still WIP. Adresses the following 2 things:

- Issue #1 - Update the README to include baselines - I want to extend the README a bit further as well.
- The current travis builds are not working and so is the role
  - After replacing the intial httpd.conf with the one provided by this role, apache is unable to be restarted

The error message is the following 
```
httpd.service - The Apache HTTP Server
   Loaded: loaded (/usr/lib/systemd/system/httpd.service; enabled; vendor preset: disabled)
   Active: failed (Result: exit-code) since Fri 2018-10-26 02:01:37 UTC; 6s ago
     Docs: man:httpd(8)
           man:apachectl(8)
  Process: 91743 ExecStop=/bin/kill -WINCH ${MAINPID} (code=exited, status=1/FAILURE)
  Process: 91742 ExecStart=/usr/sbin/httpd $OPTIONS -DFOREGROUND (code=exited, status=1/FAILURE)
 Main PID: 91742 (code=exited, status=1/FAILURE)

Oct 26 02:01:37 localhost.localdomain systemd[1]: Starting The Apache HTTP Server...
Oct 26 02:01:37 localhost.localdomain httpd[91742]: AH00534: httpd: Configuration error: No MPM loaded.
Oct 26 02:01:37 localhost.localdomain systemd[1]: httpd.service: main process exited, code=exited, status=1/FAILURE
Oct 26 02:01:37 localhost.localdomain systemd[1]: httpd.service: control process exited, code=exited status=1
Oct 26 02:01:37 localhost.localdomain kill[91743]: kill: cannot find process ""
Oct 26 02:01:37 localhost.localdomain systemd[1]: Failed to start The Apache HTTP Server.
Oct 26 02:01:37 localhost.localdomain systemd[1]: Unit httpd.service entered failed state.
Oct 26 02:01:37 localhost.localdomain systemd[1]: httpd.service failed.
```

I could also open an issue for this, if this is requested :)